### PR TITLE
CASM-4413 Add craycli to the deletion image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2023-04-07
+### Changed
+- Changing the base image from alpine to opensuse and adding craycli to the image
+
 ## [0.0.1] - 2023-03-09
 ### Changed
 - Changing this from sat-install-utility to product-deletion-utility

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #
 # Dockerfile for product_deletion_utility
 
-FROM opensuse/leap:15.3
+FROM artifactory.algol60.net/csm-docker/stable/docker.io/opensuse/leap:15.4
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #
 # Dockerfile for product_deletion_utility
 
-FROM artifactory.algol60.net/csm-docker/stable/docker.io/library/alpine:3.16
+FROM opensuse/leap:15.3
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
@@ -36,7 +36,9 @@ COPY requirements.lock.txt ${INSTALLDIR}/requirements.txt
 COPY tools ${INSTALLDIR}/tools
 COPY product_deletion_utility ${INSTALLDIR}/product_deletion_utility
 COPY docker_scripts/entrypoint.sh /entrypoint.sh
+COPY zypper.sh /
 RUN chmod +x /entrypoint.sh
+RUN --mount=type=secret,id=ARTIFACTORY_READONLY_USER --mount=type=secret,id=ARTIFACTORY_READONLY_TOKEN ./zypper.sh && rm /zypper.sh
 
 # For external dependencies, always pull from internal-pip-stable-local
 
@@ -46,7 +48,6 @@ ARG PIP_EXTRA_INDEX_URL="https://arti.hpc.amslabs.hpecorp.net/artifactory/intern
 
 # RUN does not support ENVs, so specify INSTALLDIR explicitly.
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    apk update && apk add --no-cache python3 git bash && \
     python3 -m venv $VIRTUAL_ENV && \
     pip install --no-cache-dir -U pip && \
     pip install --no-cache-dir /deletion/ && \

--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
 # Product Deletion Utility
 
 The product deletion utility is a tool for deleting product components installed through the Installation and Upgrade Framework (IUF).
+This utility is launched by `prodmgr` tool for performing delete operations.
+This utility internally uses `shasta-install-utility-common` for performing actual deletion.
+
+## Usage
+
+To launch the utility independently, pull the image on the system and follow the format from the example below -
+
+```commandline
+podman run --rm --mount type=bind,src=/etc/kubernetes/admin.conf,target=/root/.kube/config,ro=true --mount type=bind,src=/etc/pki/trust/anchors,target=/usr/local/share/ca-certificates,ro=true artifactory.algol60.net/csm-docker/stable/product-deletion-utility:0.0.1 delete cos 2.5.101
+```
+
+## Built With
+
+* Opensuse
+* Python 3
+* Python Requests
+* Docker
+* [Git Flow](https://nvie.com/posts/a-successful-git-branching-model/)
+* [Gitversion](https://gitversion.net)
+* Good intentions
+
+### Dependencies
+
+Note that this container image requires the following dependencies:
+
+- craycli
+- git
+- bash
+- Various python packages as listed in [REQUIREMENTS](requirements.lock.txt)
+
+## Contributing
+
+When CONTRIBUTING, update the [CHANGELOG](CHANGELOG.md) with the new version and the change made.
+
+## Changelog
+
+See the [CHANGELOG](CHANGELOG.md) for changes. This file uses the [Keep A Changelog](https://keepachangelog.com)
+format.
+
+## Copyright and License
+This project is copyrighted by Hewlett Packard Enterprise Development LP and is under the MIT
+license. See the [LICENSE](LICENSE) file for details.

--- a/zypper.sh
+++ b/zypper.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e +xv
+trap "rm -rf /root/.zypp" EXIT
+
+SLES_REPO_USERNAME=$(cat /run/secrets/ARTIFACTORY_READONLY_USER)
+SLES_REPO_PASSWORD=$(cat /run/secrets/ARTIFACTORY_READONLY_TOKEN)
+CSM_RPMS_HPE_STABLE="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/"
+SLES_MIRROR="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
+ARCH=x86_64
+zypper --non-interactive rr --all
+zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-Basesystem-product
+zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Containers/15-SP4/${ARCH}/update?auth=basic sles15sp4-Module-Containers-update
+zypper --non-interactive ar --no-gpgcheck ${CSM_RPMS_HPE_STABLE}/sle-15sp2/?auth=basic CSM-SLE-15SP2
+zypper --non-interactive ar --no-gpgcheck ${CSM_RPMS_HPE_STABLE}/sle-15sp3/?auth=basic CSM-SLE-15SP3
+zypper update -y
+zypper install -y craycli git-core bash python3
+zypper clean -a && zypper --non-interactive rr --all && rm -f /etc/zypp/repos.d/*

--- a/zypper.sh
+++ b/zypper.sh
@@ -8,10 +8,8 @@ CSM_RPMS_HPE_STABLE="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLE
 SLES_MIRROR="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
 ARCH=x86_64
 zypper --non-interactive rr --all
-zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP3/${ARCH}/product?auth=basic sles15sp3-Module-Basesystem-product
-zypper --non-interactive ar ${SLES_MIRROR}/Updates/SLE-Module-Containers/15-SP4/${ARCH}/update?auth=basic sles15sp4-Module-Containers-update
-zypper --non-interactive ar --no-gpgcheck ${CSM_RPMS_HPE_STABLE}/sle-15sp2/?auth=basic CSM-SLE-15SP2
-zypper --non-interactive ar --no-gpgcheck ${CSM_RPMS_HPE_STABLE}/sle-15sp3/?auth=basic CSM-SLE-15SP3
+zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP4/${ARCH}/product?auth=basic sles15sp4-Module-Basesystem-product
+zypper --non-interactive ar --no-gpgcheck ${CSM_RPMS_HPE_STABLE}/sle-15sp4/?auth=basic CSM-SLE-15SP4
 zypper update -y
 zypper install -y craycli git-core bash python3
 zypper clean -a && zypper --non-interactive rr --all && rm -f /etc/zypp/repos.d/*


### PR DESCRIPTION
## Summary and Scope

For JIRA - [CASM-4413](https://jira-pro.it.hpe.com:8443/browse/CASM-4413) Integrate craycli as part of product deletion utility container 
Changes for adding craycli to the product-deletion-utility image. This internally involved modifying the base image used from alpine to opensuse to support RPM installations. Other corresponding changes are made to support the base image modification.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASM-4413](https://jira-pro.it.hpe.com:8443/browse/CASM-4413)
* Change will also be needed in `<insert branch name here>`
* Future work required by [issue id](issue link)
* Documentation changes required in [issue id](issue link)
* Merge with/before/after `<insert PR URL here>`

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * MUG
  * Local development environment
  * Virtual Shasta

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

