### PR TITLE
 CASMPET-7634  Changing base image to suse-15.7 and the required modules to fix CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2025-11-13
+### Changed
+- Changing base image to suse-15.7 and the required modules to fix CVEs
+
 ## [1.0.1] - 2024-11-19
 ### Changed
 - Changing base image to suse-15.6 as all the required modules are not present in 15.4 repository. Changing cray-product-catalog module version due to new format of cray-product-catalog.

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 #
 # Dockerfile for product_deletion_utility
 
-FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.6
+FROM artifactory.algol60.net/csm-docker/stable/registry.suse.com/suse/sle15:15.7
 
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/zypper.sh
+++ b/zypper.sh
@@ -8,8 +8,8 @@ CSM_RPMS_HPE_STABLE="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLE
 SLES_MIRROR="https://${SLES_REPO_USERNAME:-}${SLES_REPO_PASSWORD+:}${SLES_REPO_PASSWORD}@artifactory.algol60.net/artifactory/sles-mirror"
 ARCH=x86_64
 zypper --non-interactive rr --all
-zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP6/${ARCH}/product?auth=basic sles15sp6-Module-Basesystem-product
-zypper --non-interactive ar --no-gpgcheck ${CSM_RPMS_HPE_STABLE}/?auth=basic CSM-SLE-15SP6
+zypper --non-interactive ar ${SLES_MIRROR}/Products/SLE-Module-Basesystem/15-SP7/${ARCH}/product?auth=basic sles15sp7-Module-Basesystem-product
+zypper --non-interactive ar --no-gpgcheck ${CSM_RPMS_HPE_STABLE}/?auth=basic CSM-SLE-15SP7
 zypper update -y
 zypper install -y craycli git-core bash python311-base curl jq
 zypper clean -a && zypper --non-interactive rr --all && rm -f /etc/zypp/repos.d/*


### PR DESCRIPTION
## Summary and Scope

 CASMPET-7634 Changing base image to suse-15.7 and the required modules to fix CVEs

### Tested on:

  * drax

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

